### PR TITLE
use author name as stage for dev deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ node_js:
   - node
 
 install:
+  - npm i -g serverless
   - npm install --no-optional
 
 cache:
   - directories: node_modules
     
 script:
-  - npm start
+  - chmod +x ./travis-deploy/deploy.sh
+  - ./travis-deploy/deploy.sh

--- a/package.json
+++ b/package.json
@@ -3,11 +3,5 @@
   "version": "0.0.1",
   "description": "serverless crud service for santa swap",
   "author": "",
-  "license": "MIT",
-  "scripts": {
-    "start": "serverless deploy"
-  },
-  "dependencies": {
-    "serverless": "1.4.0"
-  }
+  "license": "MIT"
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -94,7 +94,7 @@ resources:
           - ''
           - - https://
             - Ref: ApiGatewayRestApi
-            - .execute-api.us-east-1.amazonaws.com/Dev
+            - '.execute-api.us-east-1.amazonaws.com/${opt:stage, self:provider.stage}'
       Export:
         Name: '${opt:stage, self:provider.stage}-UsersEndpoint'
 

--- a/travis-deploy/deploy.sh
+++ b/travis-deploy/deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+echo Getting author info from commit $TRAVIS_COMMIT
 AUTHOR_NAME=$(git log -1 $TRAVIS_COMMIT --pretty="%aN")
 FIRST_NAME=${AUTHOR_NAME%% *}
 echo Commit author is $AUTHOR_NAME, first name is $FIRST_NAME

--- a/travis-deploy/deploy.sh
+++ b/travis-deploy/deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+AUTHOR_NAME=$(git log -1 $TRAVIS_COMMIT --pretty="%aN")
+FIRST_NAME=${AUTHOR_NAME%% *}
+echo Commit author is $AUTHOR_NAME, first name is $FIRST_NAME
+
+if [ $TRAVIS_PULL_REQUEST != "false" ]; then
+    echo Not deploying serverless code on pull requests
+
+else
+    echo Deploying serverless project with code from branch: $TRAVIS_BRANCH
+    [[ $TRAVIS_BRANCH = "master" ]] && STAGE="Prod" || STAGE=$FIRST_NAME
+    echo serverless deploy --stage $STAGE
+    serverless deploy --stage $STAGE
+
+fi


### PR DESCRIPTION
@smanwaring please look this pr over and merge if good2go
- instead of calling npm script to deploy, add a custom bash script
- only deploy on merges (not pull requests anymore as already includes a merge deploy)
- if master, stage is Prod
- if not master, stage is first name of merge author (ie Phillip or Stephanie)

resolves #4 